### PR TITLE
Add links.md

### DIFF
--- a/links.md
+++ b/links.md
@@ -1,0 +1,822 @@
+|Title|URL|Description|
+| -------- |:--------:| :-----|
+|100 Top Cogsci Works|http://cogsci.umn.edu/millennium/final.html| intro.list List of the 100 top books and articles from the 20th century in Cognitive Science.|
+|AAAI Fellows* |http://www.aaai.org/Awards/fellows-list.php| intro.people A list of leading researchers recognized by the American Association for AI|
+|AAAI* |http://www.aaai.org/| intro.org The leading society for AI|
+|AARON (CyberArt)|http://www.kurzweilcyberart.com/| intro,phil,lisp.soft|
+|ACL*|http://www.cs.columbia.edu/~acl/home.html| nlp.org The Association for Computational Linguistics|
+|AI Communications|http://aicom.web.cse.unsw.edu.au/| intro.jour The major European journal on AI|
+|AI Companies*|http://www.gwu.edu/~aisoc/company.html| intro.com Comprehensive list of 100 or so AI companies.|
+|AI Company|http://www.a-i.com| intro.com Research company offers overview of AI materials. |
+|AI Depot|http://ai-depot.com/Main.html| intro.list Site for news, tutorials, discussion on AI.|
+|AI FAQ* |http://www.faqs.org/faqs/ai-faq/general/| intro.ref The standard FAQ for all of AI, in 6 parts.|
+|AI Library in C++|http://www.pixelate.co.za/AILib/| java.soft|
+|AI Magazine |http://www.aaai.org/Magazine/| intro.jour The leading magazine on AI, published by AAAI.|
+|AI Patents|http://164.195.100.11/netacgi/nph-Parser?Sect1=PTO2&Sect2=HITOFF&p=1&u=%2Fnetahtml%2Fsearch-bool.html&r=0&f=S&l=50&TERM1=artificial+intelligence&FIELD1=&co1=AND&TERM2=&FIELD2=&d=pall| intro.ref|
+|AI Patents|http://sunsite.unc.edu/patents/class/CLASS395.html| intro.ref|
+|AI Programming in Java|http://www.aiai.ed.ac.uk/training/java.html| java.soft A course in Java and AI|
+|AI Review|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm/0269-2821| intro.jour|
+|AI Search (RMIT)*|http://www.cs.rmit.edu.au/AI-Search| search.edu|
+|AI Stockmarketforum|http://www.ai-stockmarketforum.com| intro.com|
+|AI Topics*|http://www.aaai.org/AITopics/aitopics.html| intro.ref AAAI's introduction to the field.  Excellent material.|
+|AI Wisdom|http://www.aiwisdom.com| search.list A catalog of AI game articles.|
+|AI and Databases|http://www.cs.umb.edu/~dqg/cs696-1.html| logic.ref|
+|AI in Games|http://www.gameai.com| search.list An online site for games|
+|AI on the WWW|http://www.computer.org/pubs/expert/ai-www/ai-www.htm| intro.list|
+|AI: Games (Open Directory)|http://directory.google.com/Top/Computers/Artificial_Intelligence/Games/| search.list|
+|AI: the movie|http://aimovie.warnerbros.com/| intro.soft The movie by Stanley Kubrick|
+|AIAI |http://www.aiai.ed.ac.uk/| intro.edu|
+|AIBits|http://www.aibits.com/| intro.list|
+|AIExplained|http://www.aiexplained.com| intro.ref An introductory overview for a non-technical audience |
+|AIMA Bibliography* |http://www.cs.berkeley.edu/~russell/aima-bib.html| intro.ref List of all 1095 bibliography entries from Artificial Intelligence: A Modern Approach|
+|AIMA Home* |http://www.cs.berkeley.edu/~russell/aima.html| intro.ref The textbook Artificial Intelligence: A Modern Approach|
+|AIMA code in Prolog|http://www-cse.uta.edu/~holder/courses/cse5361/spr95/cse5361.html| prolog.soft Prolog code donated by Prof. Larry Holder; partial implementation of the book's code.|
+|AISB |http://www.aisb.org.uk| intro.org|
+|ANSI Ontology|http://WWW-KSL.Stanford.EDU/onto-std/index.html| logic.ref|
+|Abbadingo (Grammar Learning)|http://abbadingo.cs.unm.edu| learning.edu A contest for learning a grammar from examples.|
+|Abelson, Hal|http://www-swiss.ai.mit.edu/~hal/hal.html| lisp.people MIT prof, author of the best book on intro programming, among other things.|
+|About AI|http://aboutai.net| intro.list New version of the former about.com AI portal.|
+|Abtech|http://www.abtech.com| learning.com|
+|Acknosoft |http://www.acknosoft.com/| intro.com|
+|Active Logic (UMD)|http://www.cs.umd.edu/projects/active/active.html| logic.edu|
+|Adam Pease|http://home.earthlink.net/~adampease/professional/| logic.people Adam Pease is the Principal Consultant and CEO of Articulate Software. Formerly, he was Director of Knowledge Systems at Teknowledge.|
+|Adaptive Behavior|http://mitpress.mit.edu/journal-home.tcl?issn=10597123| learning.jour|
+|Adaptive Control|http://www.mech.gla.ac.uk/~nactftp/nact.html| learning.edu|
+|Agent Links|http://www.cs.mu.oz.au/~leon/agentlinks.html| agents.list|
+|Agent Transfer Protocol|http://www.trl.ibm.co.jp/aglets/atp/| agents.ref|
+|AgentLink|http://www.agentlink.org| agents.list Europe's Network of Excellence for Agent-Based Research|
+|AgentNews (UMBC)* |http://www.cs.umbc.edu/agentnews/| agents.news A very useful newsletter of current events in the Agents world|
+|Agentis|http://www.agentissoftware.com/home.jsp| agents.com|
+|Agentland|http://www.agentland.com| intro,agents.com|
+|Agents (IBM) |http://www.research.ibm.com/iagents/| agents.edu|
+|Agents Web (UMBC)* |http://agents.umbc.edu| agents.edu One of the best sites for agent news and software.|
+|Agents using Java|http://www.amazon.com/exec/obidos/ASIN/047139601X| java.ref A book on programming agents (mostly for the Internet) in Java|
+|Agentsheets|http://www.agentsheets.com| agents.soft IDE for developing agents and environments; designed for non-programmers.|
+|Agentware Systems|http://www.agentwaresystems.com/| agents.com|
+|Agorics|http://www.agorics.com/agorics/| uncertainty.com|
+|Agre, Phil|http://weber.ucsd.edu/~pagre/agre.html| agents,planning.people|
+|Aha, David|http://www.aic.nrl.navy.mil/~aha/| learning.people Researcher at Naval Research Labs.|
+|Alan Perlis Epigrams*|http://www-pu.informatik.uni-tuebingen.de/users/klaeren/epigrams.html| lisp.humor Former Yale Prof. dispenses nuggets of wisdom.|
+|Allen, James |http://www.cs.rochester.edu/u/james/| intro,logic,nlp.people Rochester Prof, AAAI fellow.|
+|Almond, Russ|http://www.stat.washington.edu/bayes/almond/almond.html| uncertainty.people|
+|Amazon.com's list* |http://www.amazon.com/exec/obidos/Subject=Artificial%20Intelligence| intro.ref All AI books for sale at Amazon.|
+|American Robot|http://www.americanrobot.com| robotics.com|
+|Amit's game Programming|http://www-cs-students.stanford.edu/~amitp/gameprog.html| search.ref Top rated resource for game programming - A*, pathfinding, etc.|
+|Analytical Statistics Package |http://eksl-www.cs.umass.edu/clasp.html| uncertainty.soft|
+|Anatomy of Chess Programs|http://www.cs.ualberta.ca/~tony/ICCA/anatomy.html| search.ref |
+|Angoss|http://www.angoss.com| learning.com|
+|AnswerFriend|http://www.answerfriend.com/index.htm| nlp.com Company doing NLP question answering.|
+|AnswerLogic|http://www.primus.com/Products/AnswerEngine.asp| nlp.com Company doing NLP question answering.|
+|Appelt, Doug|http://www.ai.sri.com/~appelt/| nlp,planning.people|
+|Arbib, Michael|http://www-hbp.usc.edu/people/arbib.htm| robotics.people|
+|Arizona State|http://rakaposhi.eas.asu.edu/yochan.html| planning.edu|
+|Arkin, Ronald|http://www.cc.gatech.edu/aimosaic/faculty/arkin/| robotics.people|
+|Articulate Software Inc.|http://www.articulateoftware.com| logic.com|
+|Articulate Software|http://www.articulatesoftware.com| logic.com A consulting firm based in the San Francisco California area, specializing in ontology, formal reasoning and natural language understanding. Adam Pease is the principal consultant. |
+|Artificial Intelligence* |http://www.elsevier.nl:80/inca/publications/store/5/0/5/6/0/1/| intro.jour The leading journal for AI research publications.|
+|Artificial Life|http://mitpress.mit.edu/journal-home.tcl?issn=10645462| learning.jour|
+|Artificial Life|http://www.artificial-life.com| learning.com|
+|Ascent |http://www.ascent.com/| intro,planning.com|
+|Ask Jeeves|http://www.ask.com| nlp.com Search engine company using NLP for question answering.|
+|Assistum|http://www.assistum.com/| logic.com|
+|Assoc for Uncertainty in AI |http://www.auai.org/| uncertainty.org Leading organization for researchers in Bayesian networks and related technologies.|
+|Assoc. Lisp Users|http://www.lisp.org| lisp.org|
+|Attar|http://www.attar.com/| logic.com|
+|Austrian AI |http://www.ai.univie.ac.at/oefai/oefai.html| intro.edu|
+|Auton|http://www.cs.cmu.edu/~AUTON/| learning.edu Project doing data mining.|
+|Autonomous (MIT) |http://agents.www.media.mit.edu/groups/agents/| agents.edu|
+|Autonomous Robots|http://www.wkap.nl/journalhome.htm/0929-5593| robotics.jour|
+|Babylon Expert System ftp://ftp.gmd.de/gmd/ai-research/Software/Babylon/ lisp.sof|||
+|Bacchus, Fahiem|http://www.cs.toronto.edu/~fbacchus/| planning.people|
+|Ballard, Dana|http://www.cs.rochester.edu/u/dana/| robotics.people|
+|Balzer, Bob|http://www.usc.edu/dept/cs/faculty/faculty_interests.html#Balzer| logic.people|
+|Barto, Andy|http://envy.cs.umass.edu/People/barto/barto.html| learning.people|
+|Baum, Eric|http://www.neci.nj.nec.com/homepages/eric/eric.html| learning.people|
+|Bayes Limited* |http://www.ai.mit.edu/lab/gsb/gsb-archive/gsb94-11nov11| uncertainty.humor A humorous look at how random events can influence an election.|
+|Bayes Net Toolbox (Matlab)|http://www.cs.berkeley.edu/~murphyk/Bayes/bnt.html| uncertainty.soft|
+|Bayesia|http://www.bayesia.com| uncertainty.com Company selling Bayes net software|
+|Bayesian systems|http://www.bayes.com/| uncertainty.com|
+|Bayesians list* |http://bayes.stat.washington.edu/bayes_people.html| uncertainty.people Fairly complete list of people working in Bayesian inference.|
+|Bekey, George|http://www-robotics.usc.edu/~bekey/| robotics.people|
+|Berkeley Digital Library |http://elib.cs.berkeley.edu/| nlp.edu|
+|Berkeley Robotics|http://robotics.eecs.berkeley.edu/| robotics.edu|
+|Berkeley Vision|http://http.cs.berkeley.edu/projects/vision/vision_group.html| robotics.edu|
+|Berliner, Hans |http://www.cais.net/sunburst/chess/hof_berl.html| search.people One of the leading researchers in AI game-playing algorithms particularly for chess and backgammon.|
+|Bibel, Wolfgang |http://www.inferenzsysteme.informatik.tu-darmstadt.de/~bibel/| logic.people|
+|Biological Foundations of Behavior|http://highered.mcgraw-hill.com/olc/dl/41649/san94123_ch03.pdf| intro.ref Good overview of the brain, with fancy graphics|
+|Birnbaum, Larry|http://dent.infolab.nwu.edu/infolab/people/personal.asp?ID=41| learning.people|
+|Blum, Avrim|http://www.cs.cmu.edu/afs/cs.cmu.edu/Web/People/avrim/| learning.people|
+|Boids (flocking agents)|http://www.red3d.com/cwr/boids/| planning.soft|
+|Boosting|http://www.boosting.org| learning.org Repository of info on boosting, ensemble learning, etc.|
+|BotBox|http://www.botbox.com| agents.com|
+|BotSpot*|http://www.botspot.com| agents.list Commercial provider of up-to-date information on Internet agents (bots).|
+|Boutilier, Craig|http://www.cs.ubc.ca/spider/cebly/craig.html| planning,uncertainty.people|
+|Brachman, Ron |http://www.research.att.com:80/info/rjb| logic.people|
+|Brain in a Vat|http://www.mindspring.com/~mfpatton/Tissues.htm| phil.humor|
+|Bratko, Ivan|http://www-ai.ijs.si/ailab/bratko.html| search,prolog.people|
+|Bratman, Michael|http://www-philosophy.stanford.edu/fss/mb.html| phil.people|
+|Breese, Jack|http://research.microsoft.com/users/breese/| uncertainty.people|
+|Brightware |http://www.brightware.com/| intro,logic.com|
+|Brill, Eric|http://www.cs.jhu.edu/~brill/home.html| nlp.people|
+|Brooks, Rod|http://people.csail.mit.edu/brooks/| agents,robotics,intro.people|
+|Brown |http://www.cs.brown.edu/research/ai/| intro.edu|
+|Brown U. Robotics|http://www.cs.brown.edu/research/robotics/| robotics.edu|
+|Buntine, Wray|http://www.hiit.fi/u/buntine/| uncertainty.people|
+|Burning Glass|http://www.burning-glass.com| nlp,learning.com|
+|Bylander, Tom|http://www.cs.utsa.edu/~bylander| learning.people|
+|CAMIS (Stanford Medical) |http://camis.stanford.edu/| uncertainty.edu|
+|CBCL (MIT) |http://www.ai.mit.edu/projects/cbcl/web-homepage/web-homepage.html| learning.edu|
+|CEDAR|http://www.cedar.buffalo.edu/| nlp.edu|
+|CIRL|http://www.cirl.uoregon.edu/| planning,search.edu|
+|CLIG Linguistic data grapher |http://www.ags.uni-sb.de/~konrad/clig.html| nlp.soft|
+|CLIPS |http://www.ghg.net/clips/CLIPS.html| logic,lisp.soft|
+|CMU AI Repository: NLP |http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/other/nlp.html| nlp.soft|
+|CMU NavLab|http://www.cs.cmu.edu/afs/cs.cmu.edu/project/alv/member/www/navlab_home_page.html| robotics.edu|
+|CMU Repository |http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/other/learning.html| learning.soft|
+|CMU Repository* |http://www.cs.cmu.edu/Web/Groups/AI/html/repository.html| intro.soft A collection of AI software.|
+|CMU Robotics|http://www.ri.cmu.edu/| robotics.edu|
+|CMU list |http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/other/repositories.html| intro.list|
+|CMU* |http://www.cs.cmu.edu/| intro.edu One of the top 4 leading computer science departments,  with the largest AI group in the world|
+|CS157: Computational Logic |http://logic.stanford.edu/classes/cs157/cs157.html| logic.edu|
+|Cal Tech Robotics|http://robby.caltech.edu/| robotics.edu|
+|Canny, John|http://HTTP.CS.Berkeley.EDU/~jfc/| robotics.people|
+|Carbonnel, Jaime|http://www.cs.cmu.edu/~jgc/| nlp.people|
+|Cardie, Claire|http://www.cs.cornell.edu/Info/People/cardie/| nlp.people|
+|Cedar |http://www.cedar.buffalo.edu/| nlp.edu|
+|Celex|http://www.kun.nl/celex/| nlp.ref|
+|Center for Intelligent IR (UMass) |http://ciir.cs.umass.edu/| nlp.edu|
+|Chalmers, David |http://consc.net/chalmers/| phil.people Philosophy Prof. at Arizona |
+|Charles River|http://www.cra.com/| intro,agents.com|
+|Charniak, Eugene |http://www.cs.brown.edu/people/ec/| intro,nlp,lisp.people|
+|Cheeseman, Peter|http://ic.arc.nasa.gov/ic/projects/bayes-group/people/cheeseman/| uncertainty,intro.people|
+|Chess Programming|http://www.gamedev.net/reference/programming/features/chess1/| search.soft Comprehensive tutorial on how to program chess|
+|Chess in Lisp ftp://chess.onenet.net/pub/chess/uploads/projects/ search,lisp.sof|||
+|Chicago|http://www.cs.uchicago.edu/groups/ai/ai/projects.html| planning.edu|
+|Chien, Steve|http://www-aig.jpl.nasa.gov/public/home/chien/| planning.people|
+|Chinook: checkers* |http://www.cs.ualberta.ca/%7Echinook/play.php| search.soft|
+|Chomskybot|http://stick.us.itd.umich.edu/cgi-bin/chomsky.pl| nlp.humor|
+|Classification Soc.|http://www.pitt.edu/~csna| learning.org|
+|Classification Soc.|http://www.pitt.edu/~hirtle/csna.html| learning.org|
+|Clementine|http://www.spss.com/spssbi/clementine/| learning.com Commercial datamining toolkit.|
+|Cliki CL Links|http://ww.telent.net/cliki/index| lisp.list Good collection of resources for Common Lisp|
+|Cognitive Robotics (Toronto)|http://www.cs.toronto.edu/~cogrobo/| robotics.edu|
+|Cognos|http://www.cognos.com/busintell/data_mining.html| learning.com|
+|Collins, Alan|http://www.ls.sesp.nwu.edu/people/faculty/collins.html| learning.people|
+|Colorado State AI|http://www.cs.colostate.edu/aigroup.html| intro.edu|
+|Common Lisp Hyperspec*|http://www.lispworks.com/reference/HyperSpec/Front/index_tx.htm| lisp.ref A fantastic online hyperlinked version of the Common Lisp manual|
+|Comp. Ling. Archive|http://www.aclweb.org/archive/| nlp.edu|
+|Computational Complexity of Games|http://www.ics.uci.edu/~eppstein/cgt/hard.html| search.ref Ever wonder if NxN checkers (or Go, or Hex, or ...) is NP-complete? Here's your answer.|
+|Computational Linguistics|http://mitpress.mit.edu/interface/journals/j_buttons/COLI_H.gif| nlp.jour|
+|Computational Logic |http://www.cli.com/index.html| intro,logic.com|
+|Computing Machinery|http://www.abelard.org/turpap/turpap.htm| phil.ref Turing's original paper defining AI and the Turing Test.|
+|Connectionists|http://www.cs.cmu.edu/Web/Groups/CNBC/other/connectionists.html| learning.news|
+|Cons.org|http://www.cons.org| lisp.org|
+|Constraints Archive|http://www.cirl.uoregon.edu/constraints/| logic.list|
+|Construction Grammar|http://www.constructiongrammar.org/| nlp.edu|
+|Cornell Robotics and Vision|http://www.cs.cornell.edu/Info/Projects/csrvl/csrvl.html| robotics.edu|
+|Crawford, James|http://www.cirl.uoregon.edu/crawford/crawford.html| logic.people|
+|Croft, Bruce|http://ciir.cs.umass.edu/personnel/croft.html| nlp.people|
+|Cybion|http://www.cybion.com| intro,agents.com|
+|Cycorp |http://www.cyc.com| intro,logic.com|
+|D'Ambrosio, Bruce|http://www.cs.orst.edu/~dambrosi| uncertainty.people|
+|DFKI Language Technology|http://www.dfki.de/lt/| nlp.edu|
+|DFKI NLP Registry|http://cl-www.dfki.uni-sb.de/cl/registry/draft.html| nlp.soft|
+|DFKI Saarbrucken |http://www.dfki.uni-sb.de/| intro.edu|
+|DTP Prover|http://logic.stanford.edu/software/dtp/| logic,lisp.soft|
+|Data Mining Products|http://www.xore.com/prodtable.html| learning.list|
+|Data Mining in Python|http://www.stat.columbia.edu/~jakulin/orng/| python,learning.soft Aleks Jakulin's collection of libraries: k-means clustering, fuzzy clustering and hierarchical agglomerative clustering.|
+|David Wilkins|http://www.ai.sri.com/~wilkins/| planning.people|
+|Davis, Ernest |http://cs.nyu.edu/cs/faculty/davise| logic.people|
+|Dawid, Philip|http://www.ucl.ac.uk/Stats/staff/index.html#statsdept| learning.people|
+|Daxtron Labs |http://www.daxtron.com| agents.com|
+|De Kleer, Johan  |http://www.parc.xerox.com| logic,lisp.people|
+|DeJong, Jerry|http://www.cs.uiuc.edu/CS_INFO_SERVER/DEPT_INFO/CS_FACULTY/FAC_HTMLS/dejong.html| learning.people|
+|Dean, Tom |http://www.cs.brown.edu/people/tld/home.html| intro,uncertainty,logic.people|
+|Dechter, Rina|http://www.ics.uci.edu/~wwwoffic/Dechter/dechter.html| intro,logic.people|
+|Decision Analysis list |http://www.lumina.com/DA| uncertainty.list|
+|Deep Blue/Kasparov: chess |http://www.chess.ibm.com/| search.ref|
+|Delve Project|http://www.cs.utoronto.ca/~delve/| learning.soft|
+|Dennett, Daniel |http://www.tufts.edu/~ddennett/| phil.people|
+|Dietterich, Tom|http://www.cs.orst.edu:80/~tgd/| learning.people|
+|Digital Libraries |http://sdcd.gsfc.nasa.gov/ISTO/DLT/| nlp.list|
+|Digital Libraries and Xerox |http://www.xerox.com/PARC/dlbx/library.html| nlp.edu|
+|Digitool |http://www.digitool.com| lisp.com|
+|Dorr, Bonnie|http://www.umiacs.umd.edu/users/bonnie/| nlp.people|
+|Doyle, Jon |http://www.medg.lcs.mit.edu:80/doyle/| logic,agents,planning.people|
+|Dreyfus, Bert |http://ist-socrates.berkeley.edu/~hdreyfus/| phil.people|
+|Duda, Richard|http://interface.cipic.ucdavis.edu/~duda/| learning.people|
+|Dudek, Gregory|http://www.cim.mcgill.ca/~dudek/| robotics.people|
+|Durfee, Ed |http://ai.eecs.umich.edu/people/durfee/durfee.html| agents.people|
+|Dyer, Mike|http://www.cs.ucla.edu/csd/people/faculty_pages/dyer.html| nlp.people|
+|ECCAI|http://www.eccai.org| intro.org ECCAI, the European Coordinating Committee for Artificial Intelligence|
+|EKSL (UMass) |http://eksl-www.cs.umass.edu/eksl.html| intro,agents.edu|
+|ETAI Journal|http://www.ida.liu.se/ext/etai/indexframe.html| intro.jour|
+|Ebeling, Carl |http://www.cs.washington.edu/people/faculty/ebeling.html| search.people|
+|Economics|http://www.sims.berkeley.edu/resources/infoecon/| agents.list|
+|Edinburgh |http://www.dai.ed.ac.uk/| intro.edu|
+|Elfsoft |http://users.aol.com/elfsoft/elfsoft.htm| nlp.com|
+|Elkan, Charles |http://www.medg.lcs.mit.edu:80/doyle/| logic.people|
+|Ellen Hildreth|http://www.wellesley.edu/CS/ehildreth.html| robotics.people|
+|Ellman, Tom|http://athos.rutgers.edu/~ellman/| learning.people|
+|Empirical Methods for AI|http://eksl-www.cs.umass.edu/emai.html| phil.ref|
+|Energid|http://www.energid.com| robotics.com|
+|Entrieva|http://www.entrieva.com| agents.com|
+|Epilog Prover|http://logic.stanford.edu/software/epilog/| logic,lisp.soft|
+|Epiphany|http://robotics.stanford.edu/~gjohn/| learning.com|
+|Equicom Inc.|http://www.matrixreasoning.com| learning.com Company providing 'matrix reasoning' pattern recognition software; some technical material on the site.|
+|Etchemendy, John|http://www-csli.stanford.edu/hp/etchemendy.html| phil.people|
+|Etherington, David|http://www.cirl.uoregon.edu/etherington/index.html| logic.people|
+|Ethics in Computing|http://www.eos.ncsu.edu/eos/info/computer_ethics/| phil.ref|
+|Evolution Robotics|http://www.evlution.com| robotics.com|
+|Evolution Robotics|http://www.evolution.com| robotics.com|
+|Evolutionary Computation|http://mitpress.mit.edu/journal-home.tcl?issn=10636560| learning.jour|
+|Excalibur|http://www.excalib.com| intro,nlp.com|
+|Excite's list |http://www.excite.com/computers_and_internet/computer_science/artificial_intelligence/| intro.list|
+|ExperTelligence |http://www.expertelligence.com/| intro,logic.com|
+|Fayyad, Usama|http://www.digimine.com/about/fayyad.asp| uncertainty.people|
+|Feigenbaum, Ed|http://www-ksl.stanford.edu/people/eaf/| intro,logic.people One of the founders of  expert systems and knowledge representation; former chief scientist of the USAF|
+|Fetch Technologies|http://www.fetch.com| nlp,learning.com|
+|Finin, Tim |http://www.cs.umbc.edu/~finin| agents.people University of Maryland Prof.|
+|Fisher, Douglas|http://sources.vanderbilt.edu/profile.cfm?ID=162| learning.people|
+|Forbus, Ken |http://www.ls.sesp.nwu.edu/people/faculty/forbus/| logic,lisp.people|
+|Formal Reasoning (Stanford)|http://www-formal.stanford.edu/| logic.edu|
+|Forsyth, David|http://www.cs.berkeley.edu/~daf/| robotics.people|
+|Franz |http://www.franz.com| lisp.com Leading vendor of Lisp compilers.|
+|Freuder, Eugene|http://www.cs.unh.edu/Faculty/ecf.html| logic.people|
+|Friedman, Jerome|http://stat.stanford.edu/people/faculty/friedman.html| learning.people|
+|Friedman, Nir|http://robotics.stanford.edu/people/nir| uncertainty.people|
+|FutureAI|http://www.futureai.com/| intro.list Site for news on AI and robotics.|
+|GA List|http://www.aic.nrl.navy.mil/galist/| learning.news|
+|GIB (Bridge)|http://www.cirl.uoregon.edu/ginsberg/gibresearch.html| search.soft|
+|GSB/GSL (MIT) |http://www.ai.mit.edu/people/cgdemarc/gsbgsl.html| intro.list|
+|Gabitus|http://www.gabitus.com| learning.com|
+|Game Links|http://www.dis.uniroma1.it/~cadoli/projects/Local++/| search.list AIForge's list of game programming links, some with an AI emphasis.|
+|Game Theory hotlist|http://www.cs.wustl.edu/~sds/lists/gametheory.html#agentlearn| agents.list|
+|GameDev.net AI|http://www.gamedev.net/reference/list.asp?categoryid=18| search.list Links to sites about using AI in game programming|
+|Gamesman|http://www.cs.berkeley.edu/%7Eddgarcia/software/gamesman/| search.soft A course in data abstraction and game theory using Scheme code|
+|Gasser, Les |http://www.cise.nsf.gov:80/iris/ITOPDhome-02.html| agents.people|
+|Gat, Erann|http://www-aig.jpl.nasa.gov/public/home/gat/| robotics.people|
+|Geffner, Hector|http://www.ldc.usb.ve/~hector| logic.people|
+|Gender Genie|http://www.bookblog.net/gender/genie.php| nlp.soft Program guesses if a passage is written by a male or female.|
+|Generation 5|http://library.advanced.org/18242/index.shtml| intro.list|
+|Genesereth, Michael|http://logic.stanford.edu/people/genesereth/| logic,agents,intro.people|
+|Gensym |http://www.gensym.com| intro,planning,logic.com|
+|Gentner, Deidre|http://www.psych.nwu.edu/psych/people/faculty/gentner/gentner.html| learning.people|
+|Georgia Tech |http://www.cc.gatech.edu/ai/| intro.edu|
+|Ginsberg, Matt|http://www.cirl.uoregon.edu/ginsberg/index.html| intro,logic.people|
+|Girls just wanna defun|http://www.poppyfields.net/filks/00103.html| lisp.humor|
+|Go Bibliography|http://www.gobooks.info| search.ref|
+|Goldman, Robert|http://rpgoldman.real-time.com/| planning.people|
+|Goldszmidt, Moises|http://robotics.stanford.edu/~moises/| uncertainty.people|
+|Google (AI)|http://www.google.com/search?q=artificial+intelligence| intro.list|
+|Google (Agents)|http://www.google.com/search?q=artificial+intelligence+agents| agents.list|
+|Google (C++)|http://www.google.com/search?q=artificial+intelligence+programming+c%2B%2B| java.list|
+|Google (Java)|http://www.google.com/search?q=artificial+intelligence+programming+java| java.list|
+|Google (KR)|http://www.google.com/search?q=artificial+intelligence+knowledge+representation| logic.list|
+|Google (Learning)|http://www.google.com/search?q=artificial+intelligence+machine+learning| learning.list|
+|Google (Lisp)|http://www.google.com/search?q=artificial+intelligence+programming+lisp| lisp.list|
+|Google (Logic)|http://www.google.com/search?q=artificial+intelligence+logic| logic.list|
+|Google (NLP)|http://www.google.com/search?q=artificial+intelligence+natural+language| nlp.list|
+|Google (Philosophy)|http://www.google.com/search?q=artificial+intelligence+philosophy| phil.list|
+|Google (Planning)|http://www.google.com/search?q=artificial+intelligence+planning| planning.list|
+|Google (Prolog)|http://www.google.com/search?q=artificial+intelligence+programming+prolog| prolog.list|
+|Google (Python)|http://www.google.com/search?q=artificial+intelligence+programming+python| python.list|
+|Google (Robotics)|http://www.google.com/search?q=artificial+intelligence+robotics| robotics.list|
+|Google (Search)|http://www.google.com/search?q=artificial+intelligence+search| search.list|
+|Google (Uncertainty)|http://www.google.com/search?q=artificial+intelligence+uncertainty| uncertainty.list|
+|Google|http://www.google.com| nlp.com|
+|Graham, Paul|http://www.artix.com/biz/artix/who.a.html| lisp.people|
+|Graphplan Homepage|http://almond.srv.cs.cmu.edu/afs/cs.cmu.edu/usr/avrim/www/graphplan.html| planning.ref|
+|Green, Cordell|http://www.kestrel.edu/home/people/green/| logic.people|
+|Grosof, Benjamin|http://ebusiness.mit.edu/bgrosof/| logic,agents.people|
+|Grosz, Barbara|http://www.eecs.harvard.edu/grosz/| intro,nlp.people|
+|Gruden, Rod|http://www-robotics.cs.umass.edu/~grupen/home.html| robotics.people|
+|HPSG Group|http://hpsg.stanford.edu/| nlp.edu|
+|HPSG parser|http://eoan.stanford.edu/ergo/parser.html| nlp.soft|
+|HTK Hidden Markov Toolkit|http://htk.eng.cam.ac.uk/| java.soft Good toolkit for building Hidden Markov Models|
+|Hacker's Dictionary|http://www.tuxedo.org/~esr/jargon| lisp.humor|
+|Haddawy, Peter|http://www.cs.uwm.edu/faculty/haddawy| uncertainty.people|
+|Haley Enterprise|http://www.haley.com/| intro,logic.com|
+|Hall, Marty|http://www.apl.jhu.edu/~hall/| java.people|
+|Hammond, Kris|http://people.cs.uchicago.edu/~kris/| learning.people|
+|Hannibal (Othello)|http://www.cam.org/~bigjeff/Hannibal.html| search.soft|
+|Hansen, Eric|http://WWW.CS.MsState.Edu/~hansen| planning.people|
+|Hart, Peter|http://www.rii.ricoh.com/~hart/| learning.people|
+|Harvard Robotics|http://hrl.harvard.edu/| robotics.edu|
+|Haussler, David|http://www.cse.ucsc.edu/personnel/faculty/haussler.html| learning.people|
+|Hayes, Pat |http://www.coginst.uwf.edu/~phayes/| logic,intro.people|
+|Hayes-Roth, Barbara |http://www-ksl.stanford.edu:80/people/bhr/index.html| agents.people|
+|Hearst, Marti|http://www.sims.berkeley.edu/~hearst/| nlp,agents.people|
+|Heckerman, David|http://research.microsoft.com/~heckerman/| intro,uncertainty.people|
+|Hendler, Jim|http://www.cs.umd.edu/users/hendler| learning,planning.people|
+|Henrion, Max|http://www.lumina.com| uncertainty.people|
+|Hewitt, Carl|http://www.ai.mit.edu/people/hewitt/hewitt.html| lisp.people|
+|Hinton, Geoffrey |http://www.gatsby.ucl.ac.uk/Hinton| intro,learning,uncertainty.people|
+|Hirsh, Hyam|http://athos.rutgers.edu:80/~hirsh/| learning,uncertainty.people|
+|History of Game Theory|http://william-king.www.drexel.edu/top/class/histf.html| uncertainty.ref|
+|History of Lisp 1|http://www-formal.stanford.edu/jmc/history/lisp.html| lisp.ref|
+|History of Lisp 2|http://www8.informatik.uni-erlangen.de/html/lisp-enter.html| lisp.ref|
+|Hobbs, Jerry |http://www.ai.sri.com/~hobbs/| logic,nlp.people|
+|Hofstader, Doug|http://www.psych.indiana.edu/people/homepages/hofstadter.html| learning.people|
+|Hogg, Tad|http://www.hpl.hp.com/research/scl/people/tad/| agents,robotics.people Expert in multiagent systems and quantum computing|
+|Honavar, Vasant|http://www.cs.iastate.edu/~honavar/| learning,agents.people|
+|Horn, Berthold|http://www.ai.mit.edu/people/bkph/bkph.html| lisp,robotics.people|
+|Horvitz, Eric|http://www.research.microsoft.com/research/dtg/horvitz/| uncertainty,intro.people|
+|Hovy, Ed|http://www.isi.edu/natural-language/people/hovy.html| nlp.people|
+|Hubble Space Telescope |http://www.stsci.edu/public/sst/| planning.edu Use of AI planning and scheduling techniques for the Hublle Space Telescope.|
+|Hugin |http://www.hugin.com| intro,uncertainty.com|
+|Huhns, Michael |http://www.cse.sc.edu/~huhns/| agents.people|
+|Human Language Survey|http://www.cse.ogi.edu/CSLU/HLTsurvey/HLTsurvey.html| nlp.ref|
+|Hyperparallel|http://www.hyperparallel.com/main.html| learning.com|
+|IA Zoom|http://www.iazoom.com.br/lisp.htm| intro.list AI Portal in Portugese|
+|IBM Data Mining|http://www.software.ibm.com/data/intelli-mine/| learning.com|
+|I-C2 Systems|http://www.i-c2.com| intro,agents,planning.com|
+|IEEE |http://www.computer.org/| intro.org|
+|IEEE Intelligent Systems|http://www.computer.org/intelligent/| intro.jour|
+|IJCAI |http://ijcai.org/| intro.org The International Joint Conference on AI|
+|INFORMS|http://www.informs.org| learning.org|
+|IS Robotics|http://www.isr.com/| robotics.com|
+|ISI|http://www.isi.edu/sims/knoblock/abstraction.html| planning.edu|
+|Illinois |http://www.cs.uiuc.edu/CS_INFO_SERVER/DEPT_INFO/CS_RESEARCH/RESEARCH_AREAS/ai.html| intro.edu|
+|InXight|http://www.inxight.com| nlp.com|
+|Information Discovery|http://www.datamining.com| learning.com|
+|Inquizit|http://www.inquizit.com/| nlp.com|
+|Intellicorp|http://www.intellicorp.com| logic,intro.com|
+|Intelligent Java Applications|http://www.mkp.com/books_catalog/bookpage.asp?id=1-55860-420-0&cart=| java.soft|
+|Intelligent Wireless Web|http://www.amazon.com/exec/obidos/ASIN/0201730634| agents.ref|
+|Interactive Programming in Java|http://www.cs101.org/index| java.soft The Rethinking CS101 project; this site investigates what happens if we build software as agents rather than algorithms.|
+|Interactive Prolog Guide|http://kti.mff.cuni.cz/~bartak/prolog.old/index.html| prolog.ref|
+|Intnl. Comp. Chess Ass.|http://www.dcs.qmw.ac.uk/~icca/| search.org|
+|Intro to AI|http://tqd.advanced.org/2705/| intro.ref|
+|Intro to ILP|http://www.comlab.ox.ac.uk/activities/machinelearning/ilp_theory.html| learning.ref Introduction to the theory of Inductive Logic Programming|
+|Introduction to ML (Nilsson)|http://robotics.stanford.edu/people/nilsson/mlbook.html| learning.ref|
+|Iowa State|http://www.cs.iastate.edu/~honavar/aigroup.html| learning,agents.edu|
+|Irvine ML programs|http://www.ics.uci.edu/~mlearn/MLPrograms.html| learning.soft|
+|Irvine Machine Learning* |http://www.ics.uci.edu/~mlearn/MLRepository.html| learning.org A repository of data sets for comparing machine learning algorithms.|
+|Irvine|http://www.ics.uci.edu/~mlearn/Machine-Learning.html| intro,learning.edu|
+|Isabelle theorem prover|http://isabelle.in.tum.de/| logic.soft|
+|Israel, David|http://www.ai.sri.com/~israel/| nlp,phil.people|
+|J. Cog. Neuroscience|http://mitpress.mit.edu/journal-home.tcl?issn=0898929X| learning.jour|
+|J. Computer Vision|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm?0920-5691| robotics.jour|
+|J. Digital Libraries|http://link.springer.de/link/service/journals/00799/index.htm| nlp.jour|
+|J. Funct. &amp; Logic Prog.|http://mitpress.mit.edu/journal-home.tcl?issn=10805230| lisp.jour|
+|J. Learning Sciences|http://www.cc.gatech.edu/aimosaic/faculty/kolodner/jls/| learning.jour|
+|J. of Automated Reasoning|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm?0168-7433| learning.jour|
+|JAIR* |http://www.cs.washington.edu/research/jair/home.html| intro.jour The leading online journal of AI Research.|
+|JESS rule engine|http://herzberg.ca.sandia.gov/jess/| java.soft|
+|JPL (NASA) AI|http://www-aig.jpl.nasa.gov/| intro.edu NASA's Jet Propulsion Lab runs the robotic exploration of the planets.|
+|JPL AI Group|http://www-aig.jpl.nasa.gov/| intro.edu|
+|JPL Planning Group|http://www-aig.jpl.nasa.gov/public/planning/| planning.edu|
+|JSAT|http://cafe.newcastle.edu.au/daniel/JSAT/| logic,java.soft The Java Satisfiability Library: variants of the DPLL algorithm.|
+|Jam Project|http://www.cs.columbia.edu/~sal/JAM/PROJECT/| learning.edu|
+|Java Links*|http://www.apl.jhu.edu/~hall/java/| java.list Large collection of links for Java.|
+|JavaBayes|http://www.cs.cmu.edu/afs/cs/usr/fgcozman/www/Research/BayesNet/index/index.html| java.ref Free Java code to develop and evaluate Bayesian Networks.|
+|Jaynes' book|http://omega.albany.edu:8008/JaynesBook.html| uncertainty.ref|
+|Joe Lisp|http://fivedots.coe.psu.ac.th/~ad/humour/jlisp.html| lisp.humor|
+|Johns Hopkins Robotics|http://caesar.me.jhu.edu/| robotics.edu|
+|Jordan, Michael|http://www.cs.berkeley.edu/~jordan/| intro,learning,uncertainty.people Berkeley Prof., pioneer in neural nets, recently working on Bayesian nets and Graphical Models.|
+|Joshi, Arvind|http://www.cis.upenn.edu/~ircs/joshi.html| intro,nlp.people|
+|Journal of Stat Software|http://www.stat.ucla.edu/journals/jss/| learning.jour|
+|KR.org|http://www.kr.org| logic.org|
+|Kaelbling, Leslie |http://www.cs.brown.edu/people/lpk/home.html| agents,intro,uncertainty.people|
+|Kambhampati, Rao|http://rakaposhi.eas.asu.edu/rao.html| planning.people|
+|Kanal, Laveen |http://www.cs.umd.edu:80/users/kanal/| search.people|
+|Kantrowitz, Mark|http://www.kantrowitz.com/kantrowitz/mark.html| lisp.people|
+|Karlsruhe Bibliography|http://liinwww.ira.uka.de/bibliography/| intro.ref|
+|Kasif, Simon |http://www.cs.jhu.edu/kasif/home.html| learning,uncertainty.people|
+|Kasparov, Gary |http://www.kasparov.com/| search.people Russian chess champion|
+|Katz, Boris|http://www.ai.mit.edu/people/boris/boris.html| nlp.people|
+|Kautz, Henry|http://www.cs.washington.edu/homes/kautz/| logic,intro.people|
+|Kearns, Micahel|http://www.cis.upenn.edu/~mkearns/| learning.people|
+|Kibler, Dennis|http://www.ics.uci.edu/~kibler/| learning.people|
+|Kluwer Journals|http://www.wkap.nl/jrnlsubject.htm/M+0+0+0| intro.jour|
+|Knight, Kevin|http://www.isi.edu/natural-language/people/knight.html| nlp.people|
+|Knight, Tom|http://www.ai.mit.edu/people/tk/tk.html| lisp.people|
+|Knoblock, Craig|http://www.isi.edu/sims/knoblock/homepage.html| planning,learning.people|
+|Knowledge Discovery Mine|http://www.kdnuggets.com| learning.list|
+|Knowledge Discovery&amp;Datamining |http://www.kdd.org| learning.list|
+|Knowledge Industries |http://www.kic.com/| intro,uncertainty.com|
+|Knowledge Systems (Australia)|http://www.cse.unsw.edu.au/~ksg/| logic.edu|
+|Knowledge in Games|http://www.ai.univ-paris8.fr/~cazenave/SpecInGames/SpecializationInGames.html| search.ref|
+|Koalog|http://www.koalog.com/php/jcs.php| search,planning.com A company offering software for constraint solving and planning and scheduling.|
+|Koenig, Sven|http://idm-lab.org/| learning,robotics,uncertainty.people|
+|Koller, Daphne|http://robotics.stanford.edu/~koller| logic,uncertainty.people|
+|Kolodner, Janet|http://www.cc.gatech.edu/aimosaic/faculty/kolodner/| intro,learning.people|
+|Konolidge, Kurt |http://www.ai.sri.com/~konolige/| logic.people|
+|Korf, Richard |http://www.cs.ucla.edu/~korf/| intro,search.people|
+|Kowalski, Robert |http://www-lp.doc.ic.ac.uk/UserPages/staff/rak/rak.html| logic,agents.people|
+|Koza, John|http://www.genetic-programming.com/johnkoza.html| learning.people|
+|Kumar, Vipin |http://www.cs.umn.edu/faculty/kumar.html| search.people|
+|Kurzweil |http://www.kurzweiltech.com| intro,robotics.com|
+|LPA|http://www.lpa.co.uk/| intro,prolog.com|
+|Laird, John|http://ai.eecs.umich.edu/people/laird/index.html| learning,agents.people|
+|Lakoff, George |http://userwww.sfsu.edu/~rsauzier/Lakoff.html| logic,nlp.people|
+|Langley, Pat |http://robotics.stanford.edu/users/langley/| learning.people|
+|Langsoft|http://www.langsoft.ch| nlp.com|
+|Language Shootout|http://www.bagley.org/~doug/shootout/| java,lisp,python,prolog.ref List of comparisons of many programming languages for speed, memory, lines of code on small benchmarks|
+|Lansky, Amy|http://www.renresearch.com/| planning.people|
+|Learning Sciences|http://www.sesp.northwestern.edu/LS/| learning.edu|
+|Lehnert, Wendy |http://ciir.cs.umass.edu/personnel/lehnert.html| intro,nlp.people|
+|Lemonodor|http://www.lemonodor.com| lisp.list A mostly Lisp weblog by John Wiseman|
+|Lenat, Douglas|http://www.cyc.com/staff.html| agents,logic,learning.people|
+|Lesser, Victor |http://dis.cs.umass.edu/lesser.html| agents.people|
+|Levesque, Hector|http://www.cs.toronto.edu/~hector/| agents,logic.people|
+|Lewis, David|http://www.daviddlewis.com/| learning,nlp.people|
+|Lieberman, Henry |http://lieber.www.media.mit.edu/people/lieber| agents.people|
+|Lifschitz, Vladimir|http://www.cs.utexas.edu/users/vl| logic.people|
+|Ling, Charles|http://www.csd.uwo.ca/faculty/ling/| learning.people|
+|Lingo Motors|http://www.lingomotors.com/home2.html| nlp.com|
+|Linguist|http://www.emich.edu/~linguist/| nlp.news|
+|Linguistic Data Consortium|http://www.ldc.upenn.edu/| nlp.org|
+|Linguistic Technology|http://www.englishwizard.com| nlp.com|
+|Linguistics &amp; NLP list|http://www.eskimo.com/~rickw/linguistics.html| nlp.list|
+|Link Grammar|http://www.link.cs.cmu.edu/link/| nlp,java.soft|
+|Lisp &amp; Symbolic Computation|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm?0892-4635| lisp.jour|
+|Lisp FAQ*|http://www.cs.cmu.edu/Web/Groups/AI/html/faqs/lang/lisp/top.html| lisp.ref Answers your questions about where to get Lisp compilers and code,  and some questions about how to program in Lisp.|
+|Lisp HTTP Server|http://www.ai.mit.edu/projects/iiip/doc/cl-http/home-page.html| lisp.soft|
+|Lisp Humor*|http://www.elwoodcorp.com/alu/humor/lisp-humor.html| lisp.humor|
+|Lisp Packages|http://www.cs.nwu.edu/academics/courses/c25/readings/packages.html| lisp.ref|
+|Lisp Refs (CMU)|http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/lang/lisp/0.html| lisp.list|
+|Lisp Textbook Code|http://yoda.cis.temple.edu:8080/UGAIWWW/books/index.html| lisp.list|
+|Lisp Tutorial (Civilized)|http://www.civilized.com/LispBook/| lisp.ref|
+|Lisp Tutorial (Hopkins)|http://www.apl.jhu.edu/~hall/lisp.html| lisp.ref|
+|Lisp Tutorial (Texas A&amp;M)|http://grimpeur.tamu.edu/~colin/lp/| lisp.ref|
+|Lisp, C++, Java, Dylan|http://www.computer.org/pubs/expert/1996/trends/x10010/lisp.htm| lisp,java.ref|
+|Local++|http://www.dis.uniroma1.it/~cadoli/projects/Local++/| search,java.soft A C++ framework for local search techniques.|
+|Loebner Prize|http://loebner.net/Prizef/loebner-prize.html| intro.org|
+|Logic Software |http://www-csli.stanford.edu/hp/| logic.soft|
+|Logical Fallacies* |http://www.datanation.com/fallacies/| logic.ref|
+|Logistello (Othello)|http://www.cs.ualberta.ca/~mburo/log.html| search.soft|
+|Logistello (Othello)|http://www.neci.nj.nec.com/homepages/mic/| search.soft|
+|Lozano-Perez, Tomas|http://www.ai.mit.edu/people/tlp/tlp.html| learning.people|
+|Lumina |http://www.lumina.com/| intro,uncertainty.com|
+|MAS Journal|http://www.wkap.nl/journalhome.htm/1387-2532| agents.jour|
+|MCMC Papers|http://www.statslab.cam.ac.uk/~mcmc| learning.list Preprints of papers on Markov chain Monte Carlo techniques.|
+|MIT Clinical Decision Making |http://medg.lcs.mit.edu/| uncertainty.edu|
+|MIT Mobile Robots|http://www.ai.mit.edu/projects/mobile-robots/| robotics.edu Rodney Brooks and his students and co-workers.|
+|MIT Robotics FAQ ftp://rtfm.mit.edu/pub/usenet/news.answers/robotics-faq/ robotics.re|||
+|MIT* |http://www.ai.mit.edu/| intro.edu One of the 4 top CS departments and AI groups.|
+|ML Journal|http://www.cs.cmu.edu/afs/cs.cmu.edu/user/mitchell/ftp/mlj.html| learning.jour|
+|ML Programs (CMU) |http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/areas/learning/systems/utexas/progs/0.html| learning.soft|
+|ML Resources*|http://www.aic.nrl.navy.mil/~aha/research/machine-learning.html| learning.list|
+|ML/CBR People* |http://www.aic.nrl.navy.mil/~aha/people/all.html| learning.people An excellent list of links to people in the machine learning community with emphasis on case-based reasoning.|
+|MLC++ |http://www.sgi.com/tech/mlc| learning,java.soft|
+|Machine Learning |http://mlis.www.wkap.nl/| intro,learning.jour|
+|Machine Learning Dictionary|http://www.cse.unsw.edu.au/~billw/mldict.html| learning.ref Comprehensive set of online definitions, with links|
+|Machine Learning in Games  |http://satirist.org/learn-game/| learning,search.list|
+|Machine Translation|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm?0922-6567| nlp.jour|
+|Mackworth, Alan|http://www.cs.ubc.ca/spider/mack/| logic,robotics.people|
+|Maes, Pattie |http://pattie.www.media.mit.edu/people/pattie/| intro,agents.people|
+|Mahadevan, Sridhar|http://www.cs.umass.edu/~mahadeva/| learning,robotics.people|
+|Malik, Jitendra|http://HTTP.CS.Berkeley.EDU/~malik/| robotics.people Berkeley Prof. working in computer vision.|
+|Managing Gigabytes*|http://www.cs.mu.OZ.AU/mg/| nlp.soft Book that clearly and practically explains how to build an Information Retrieval system. Many systems have been built around the IR code provided here.|
+|Marcus, Mitch|http://www.cis.upenn.edu/~mitch/home.html| nlp.people|
+|Mark Watson|http://www.markwatson.com/books/books.htm| agents.soft|
+|Mataric, Maja|http://www.cs.brandeis.edu/~maja/| robotics.people Brandeis Prof. working in robotics.|
+|Math Methods of OR|http://www.mathematik.uni-ulm.de/or/allgemeines/MMOR/mmor.html| uncertainty.jour|
+|Math of Language|http://www.cis.upenn.edu/~ircs/mol/mol.html| nlp.org|
+|Mathematics HQ|http://mathematicshq.com| intro.list List of links to math sites|
+|Matroid Decomposition|http://www.utdallas.edu/~klaus/mbook.html| logic.ref|
+|McAllester, David|http://www.ai.mit.edu/people/dam/dam.html| search.people|
+|McCarthy, John |http://www-formal.stanford.edu/jmc/| logic,intro.people One of the founders of AI, gave the field its name.  Stanford Prof. concentrating on nonmonotonic reasoning.|
+|McCoy, Kathy|http://www.eecis.udel.edu/~mccoy/| nlp.people|
+|McCune, William|http://www.mcs.anl.gov/people/mccune/index.html| logic.people|
+|McDermott, Drew |http://cs-www.cs.yale.edu/homes/dvm/| intro,logic,learning,lisp.people|
+|McGill|http://www.cim.mcgill.ca/| robotics.edu|
+|Mellish, Chris|http://www.dai.ed.ac.uk/homes/chrism/| prolog.people|
+|Mercury|http://www.cs.mu.oz.au/research/mercury/| prolog.soft|
+|Michie, Donald |http://www.aiai.ed.ac.uk/~dm/dm.html| intro,search.people|
+|Michigan |http://ai.eecs.umich.edu/| intro.edu|
+|Micro Control Jornal|http://www.mcjournal.com/| robotics.jour|
+|Microsoft DTG* |http://www.research.microsoft.com/research/dtg/| uncertainty,intro.edu The group that brought Bayesian reasoning to the problem of diagnosing problems in Windows.|
+|Miikkulainen, Risto|http://www.cs.utexas.edu/users/risto/| learning.people|
+|MindShadow|http://www.mindshadow.com| learning.com Company using machine learning for Customer Relationship Management, etc.|
+|Minds &amp; Machines|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/journalhome.htm?0924-6495| phil.jour|
+|Minimum Message Length |http://www.csse.monash.edu.au/~lloyd/tildeMML/index.html| learning.edu|
+|Minsky, Marvin |http://www.ai.mit.edu/people/minsky/minsky.html| intro,learning.people|
+|Minton, Steve|http://www.isi.edu/sims/minton/homepage.html| learning.people|
+|Mitchell, Melanie|http://www.santafe.edu/~mm/| learning.people|
+|Mitchell, Tom |http://www.cs.cmu.edu/afs/cs.cmu.edu/user/mitchell/ftp/tomhome.html| intro,learning.people CMU Prof. in machine learning, founder of WhizBang Labs, AAAI Fellow, and former president of AAAI.|
+|Mooney, Ray|http://www.cs.utexas.edu/users/mooney/| learning,nlp.people|
+|Moore, Andrew |http://www.cs.cmu.edu/afs/cs/user/awm/web/hp.html| intro,uncertainty,learning.people|
+|Moore, Johanna|http://www.cogsci.ed.ac.uk/~jmoore/| nlp.people|
+|Moore, Robert|http://www.ai.sri.com/~bmoore/| nlp.people|
+|Moravec, Hans|http://www.frc.ri.cmu.edu/~hpm/| robotics.people|
+|Morgenstern, Leora|http://steam.stanford.edu/leora| logic.people|
+|Mueller, Erik|http://www.panix.com/~erik/index.html| nlp.people|
+|Muggleton, Steve|http://www.comlab.ox.ac.uk/oucl/people/steve.muggleton.html| learning.people|
+|Multi-Agent Pointers|http://expasy.hcuge.ch/sgaico/html/olb/Sources/Access/Pointers.html| agents.list|
+|Multiagent Dynamics ftp://parcftp.xerox.com/pub/dynamics/multiagent.html agents.re|||
+|Murphy, Robin|http://www.csee.usf.edu/~murphy/| robotics.people|
+|NASA AI Group|http://ti.arc.nasa.gov/| intro.edu|
+|NASA Automated Learning Group|http://ic.arc.nasa.gov/ic/projects/bayes-group/| learning.edu Peter Cheeseman and David Wolpert lead this group involved in bayesian model-based learning.|
+|NASA Bayesian Group |http://ic-www.arc.nasa.gov/ic/projects/bayes-group/index.html| uncertainty,learning.edu|
+|NASA Robots|http://robotics.jpl.nasa.gov/groups/rv/homepage.html| robotics.edu|
+|NEC Research|http://www.neci.nj.nec.com| learning.edu|
+|NL software registry|http://registry.dfki.de/| nlp.soft|
+|NLBean (Java)|http://www.markwatson.com/opensource/opensource.htm| nlp,java.soft|
+|NLP Dictionary|http://www.cse.unsw.edu.au/~billw/nlpdict.html| nlp.ref |
+|NYU Linguistics* |http://www.nyu.edu/pages/linguistics/| nlp.edu|
+|Nau, Dana |http://www.cs.umd.edu/~nau/| search,planning.people|
+|Naval Research Lab|http://www.aic.nrl.navy.mil/~gref/section.html| learning.edu|
+|Neal, Radford|http://www.cs.utoronto.ca/~radford| learning,uncertainty.people|
+|Negotiation Bib|http://www.business.carleton.ca/interneg/reference/bibliography.html| agents.ref|
+|NeoVista|http://www.neovista.com/| learning.com|
+|Neural Net FAQ|http://www.aic.nrl.navy.mil/~aha/research/txt/searle.txt| learning.list|
+|Neural Nets vs Statistics|http://www.aic.nrl.navy.mil/~aha/research/txt/searle.txt| learning.list|
+|Neural Software|http://wwwipd.ira.uka.de/~prechelt/FAQ/nn6.html#A18| learning.soft|
+|NeuralWare|http://www.neuralware.com/prod01.htm| learning.com|
+|NeuroDimension|http://www.nd.com| learning.com|
+|Neuron Data |http://www.neurondata.com/| intro,logic,learning.com|
+|Nevatia, Ram|http://iris.usc.edu/home/iris/nevatia/User.html| robotics.people|
+|New South Wales |http://www.cse.unsw.edu.au/~aishare/| intro.edu|
+|New South Wales|http://www.cse.unsw.edu.au/~aishare/3.RESEARCH_THEMES/MACHINE.LEARNING/mach.learn.html| learning.edu|
+|Newell, Allen|http://www.cs.cmu.edu/csd/newell.html| intro.people|
+|Nilsson, Nils |http://robotics.stanford.edu/users/nilsson/| intro,logic,search,planning,agents.people|
+|Norsys |http://www.norsys.com/| intro,uncertainty.com|
+|Norvig, Peter |http://www.norvig.com| agents,nlp,lisp,python.people AAAI Fellow and co-author of Artificial Intelligence: A Modern Approach.|
+|NovaCast|http://www.novacast.se/| logic.com|
+|NovaGenetica|http://www.novagenetica.com| search.com|
+|Novak, Gordon|http://www.cs.utexas.edu/users/novak/index.html| logic.people|
+|Nuance |http://www.nuance.com/| nlp.com|
+|Nute, Donald|http://www.arches.uga.edu/~dnute/| logic,phil.people|
+|O'Keefe, Richard |http://www.cs.otago.ac.nz/staff/richard.html| prolog.people|
+|O-Plan |http://www.aiai.ed.ac.uk/~oplan/| planning.edu|
+|OFAI ML List |http://www.ai.univie.ac.at/oefai/ml/ml-ressources.html| learning.list|
+|OZ Project (CMU) |http://www.cs.cmu.edu/afs/cs.cmu.edu/project/oz/web/oz.html| agents.edu|
+|Online Guide to Constraint Programming|http://kti.mff.cuni.cz/~bartak/constraints/index.html| logic.ref|
+|Online Logic Text* |http://www.hofstra.edu/~matscw/logic/logicintro.html| logic.ref|
+|Ontolingua*|http://www.ksl.stanford.edu/software/ontolingua/| logic.edu|
+|Ontology Page|http://www.medg.lcs.mit.edu/top/| logic.ref|
+|Operations Research |http://groups.google.com/groups?q=comp.sci-op.research| uncertainty.news|
+|Oregon |http://cirl.uoregon.edu/| intro.edu|
+|Ortony, Andrew|http://www.cs.northwestern.edu/~ortony/| nlp.people|
+|Otter |http://www.mcs.anl.gov/home/mccune/ar/otter/index.html| logic,java.soft|
+|PC AI |http://www.pcai.com/| intro.jour|
+|PDC (Prolog)|http://www.pdc.dk| prolog,planning.com|
+|PVS verification system|http://pvs.csl.sri.com/| logic.soft|
+|Papers on Consciousness*|http://www.u.arizona.edu/~chalmers/online.html| phil.ref David Chalmers  excellent collection of papers on consciousness and philosophy of mind.|
+|Pazzani, Mike|http://www.ics.uci.edu/~pazzani/| learning.people|
+|Pearl, Judea |http://bayes.cs.ucla.edu/jp_home.html| intro,search,uncertainty.people|
+|Peirce, Charles S* |http://www.peirce.org/peirce/| logic,phil.people One of the pioneers of logic. An excellent web site.|
+|Perlis, Don|http://www.cs.umd.edu/~perlis| logic.people|
+|Perry, John|http://www-csli.stanford.edu/~john/| phil.people|
+|Petamem|http://www.petamem.com| nlp.com Perl-based natural language understandding system|
+|Peter Bouthorn mailto:p.bouthoorn@hetnet.nl java.people Co-author of Object Oriented AI in C+|||
+|Peters, Stanley|http://www-csli.stanford.edu/users/peters/| nlp.people|
+|Philosophy list |http://eserver.org/philosophy/| phil.list|
+|Philosophy of Mind Biblio|http://www.u.arizona.edu/~chalmers/biblio.html| phil.list Comprehensive Bibliography of Philosophy of Mind by David Chalmers|
+|Philosophy papers online|http://www.u.arizona.edu/~chalmers/people.html| phil.list|
+|Pinker, Steven|http://www.mit.edu/~pinker/| nlp,phil.people|
+|Pittsburgh |http://www.isp.pitt.edu/| intro.edu|
+|Planning Domains|http://www.cs.umd.edu/projects/planning/| planning.list|
+|Planning List|http://rakaposhi.eas.asu.edu/planning-list-digest| planning.news|
+|Planning Resources|http://eksl-www.cs.umass.edu/planning-resources.html| planning.list|
+|Platinum |http://www.platinum.com/| learning.com|
+|Poggio, Tomaso|http://www.cs.utexas.edu/users/porter| learning.people|
+|Pohl, Ira |http://www.cse.ucsc.edu:80/~pohl| search.people|
+|Pollack, Jordan|http://www.cs.brandeis.edu/~pollack/| learning.people|
+|Pollack, Martha|http://www.eecs.umich.edu/~pollackm/| planning.people|
+|Pollard, Carl|http://www.cog.ohio-state.edu/people/cfaculty/pollard.html| nlp.people|
+|Ponce, Jean|http://www.beckman.uiuc.edu/faculty/ponce.html| robotics.people|
+|Poole, David|http://www.cs.ubc.ca/spider/poole| intro,logic,uncertainty.people|
+|Porter, Bruce|http://www.cs.utexas.edu/users/porter| learning.people|
+|Prediction Company|http://www.predict.com| learning.com|
+|Prolog Dictionary|http://www.cse.unsw.edu.au/~billw/prologdict.html| prolog.ref Definitions of Prolog terminology|
+|Prolog FAQ*|http://www.cis.ohio-state.edu/hypertext/faq/bngusenet/comp/lang/prolog/top.html| prolog.ref|
+|Prolog Standard|http://www.amazon.com/exec/obidos/ISBN=3540593047/6276-3025864-072092| prolog.ref|
+|Prolog Tutorial|http://www.cs.auckland.ac.nz/~jham1/07.363/prolog-for-se.html| prolog.ref|
+|Promises of Computing|http://www.cs.washington.edu/homes/lazowska/cra/ai.html| intro.ref|
+|Proof Power |http://www.lemma-one.demon.co.uk/ProofPower| logic.soft|
+|Pryor, Louise|http://www.dai.ed.ac.uk/staff/personal_pages/louisep/| planning.people|
+|Pullum, Geoff|http://ling.ucsc.edu/~pullum/index.html| nlp.people|
+|Pustejovsky, James|http://www.cs.brandeis.edu/~jamesp/| nlp.people|
+|Putnam, Hilary|http://spazioweb.inwind.it/albgaz/putnam/puteng.html| logic.people|
+|Puzzle Solving in Python|http://users.rcn.com/python/download/puzzle.py| python.soft|
+|PyroRobotics|http://pyrorobotics.org/| python,robotics.soft Robotics in Python|
+|Python Essential Ref|http://www.amazon.com/exec/obidos/ASIN/0735710910| python.ref|
+|Python vs Lisp|http://www.norvig.com/python-lisp.html| python,lisp.ref|
+|Python.org*|http://www.python.org| python.ref Home page for the open-source Python language|
+|Quinlan, Ross|http://www.cse.unsw.edu.au/~quinlan/| learning.people|
+|R.B. Jones |http://www.rbjones.com/| phil.ref|
+|R.B. Jones |http://www.rbjones.com/rbjpub/logic/| logic.ref|
+|RL, Mich. St.|http://www.cps.msu.edu/rlr| learning.edu|
+|Rapaport, W.|http://www.cs.buffalo.edu/pub/WWW/faculty/rapaport/| logic.people|
+|Reasoning About Action|http://www.cs.utep.edu/actions/researchers.html| logic.list List of researchers and groups working on logic-based planning and reasoning about action.|
+|Red Brick|http://www.redbrick.com/rbs-g/html/dmoption.html| learning.com|
+|Reinforcement (CMU)|http://www.cs.cmu.edu/Web/Groups/reinforcement/mosaic/homepage.html| learning.edu|
+|Reinforcement Learning Tutorial*|http://www.nbu.bg/cogs/events/2000/Readings/Petrov/rltutorial.pdf| learning.ref|
+|Reinforcement Learning|http://www.cps.msu.edu/rlr| learning.edu|
+|Reiser, Brian|http://www.ls.sesp.nwu.edu/people/faculty/reiser/| learning.people|
+|Reiter, Ray |http://www.cs.toronto.edu/DCS/AI/Reiter.html| intro,logic,uncertainty.people|
+|ResearchIndex*|http://citeseer.nj.nec.com/cs| intro.ref The largest collection of Computer Science research papers on the web.  Also known as CiteSeer.|
+|Resnik, Philip|http://www.umiacs.umd.edu/users/resnik/| nlp.people|
+|Reynolds, Craig|http://www.red3d.com/cwr/| learning.people Creator of the "boids" model of flocking birds and Oscar-winner.|
+|Riesbeck, Chris|http://www.cs.northwestern.edu/~riesbeck/| learning,lisp,nlp.people|
+|Riloff, Ellen|http://www.cs.utah.edu/~riloff/| nlp.people|
+|Ripley, Brian |http://www.stats.ox.ac.uk/~ripley/| learning.people|
+|Rips, Lance|http://www.psych.nwu.edu/psych/people/faculty/rips/rips.html| nlp.people|
+|Riseman, Edward|http://vis-www.cs.umass.edu/~riseman/home.html| robotics.people|
+|Risks of AI|http://www.eos.ncsu.edu/eos/info/computer_ethics/risks/ai/| phil.ref|
+|Robocup*|http://www.robocup.org| robotics.org Robotic Soccer leagues|
+|Robosapien Dance Machine|http://www.robodance.com/| robotics.soft Open source software for controlling the RoboSapien robot|
+|Robosapien|http://www.robosapienonline.com/| robotics.com Remote control anthropomorphic robot for about $100; created by an ex-JPL scientist|
+|Robotic Manipulation|http://avalon.caltech.edu/~murray/mls/| robotics.ref|
+|Robotic Systems|http://www.robotic.com/| robotics.com|
+|Robots.net|http://robots.net| robotics.ref|
+|Rochester |http://www.cs.rochester.edu/research/| intro.edu|
+|Roman Bartak|http://kti.mff.cuni.cz/~bartak/index.html| logic,prolog.people|
+|Rosenbloom, Paul|http://www.isi.edu/soar/rosenbloom/.personal.html| learning.people|
+|Rosenchein, Jeff|http://www.cs.huji.ac.il/~jeff/| agents.people|
+|RuleML|http://www.ruleml.org| logic.soft|
+|Rulequest|http://www.rulequest.com/| learning.com|
+|Russell, Stuart |http://www.cs.berkeley.edu/~russell/| agents,learning,uncertainty,intro.people Berkeley Prof., AAAI Fellow, and co-author of Artificial Intelligence: A Modern Approach.|
+|SAS|http://www.sas.com/software/data_mining/| learning.com|
+|SEL-HPC Theorem Proving Archive |http://www.dcs.qmw.ac.uk/SEL-HPC/Articles/TheoremArchive.html| logic.list|
+|SGI MineSet|http://www.sgi.com/software/mineset.html| learning.com|
+|SHAI |http://www.shai.com| intro,learning.com|
+|SIGART |http://www.acm.org/sigart| intro.org Special Interest Group on AI of the ACM.|
+|SNePS|http://www.cse.buffalo.edu/sneps/| logic.edu|
+|SOAR (CMU)|http://www.isi.edu/soar/soar.html| learning.edu|
+|SOAR expert system|http://ai.eecs.umich.edu/soar/| logic.soft The most famous software architecture for agents.|
+|Soar Technology|http://www.soartech.com| agents.com Commercializes the SOAR model for training.|
+|SPSS|http://www.spss.com/datamine/index.htm| learning.com|
+|SRI Cambridge|http://www.ldc.upenn.edu/| nlp.edu|
+|SRI NLP|http://www.ai.sri.com/natural-language/natural-language.html| nlp.edu|
+|SRI* |http://www.ai.sri.com/aic/| intro.edu Leading AI research lab.|
+|SUMO Upper Ontology|http://www.ontologyportal.org| logic.ref|
+|Sacerdoti, Earl |http://www.copernican.com:80/earl.html| logic,planning.people|
+|Sag, Ivan|http://hpsg.stanford.edu/hpsg/sag.html| nlp.people Stanford linguistics Prof.; founder of HPSG grammar.|
+|Salford Systems|http://www.salfordsystems.com| learning.com|
+|Sampson, Geoffrey|http://www.cogs.susx.ac.uk/users/geoffs/| nlp.people|
+|Sandewall, Erik|http://www.ida.liu.se/~erisa/index-eng.html| logic.people|
+|Santa Fe |http://www.santafe.edu| intro.edu Institute studying nonlinear systems and related problems.|
+|Schaeffer, Jonathan|http://www.cs.ualberta.ca/~jonathan/| search.people Alberta Prof. famous for champion checkers playing program|
+|Schank, Roger|http://www.engines4ed.org/hyperbook/misc/rcs.html|  intro,nlp.people CMU Prof.; founded the semantics-based school of NLP in 1970's; now working on computer-assisted education.|
+|Schemers|http://www.schemers.com/| lisp.com|
+|Schlimmer, Jeff mailto:schlimmer@microsoft.com learning.peopl|||
+|Schubert, Len |http://www.cs.rochester.edu/u/schubert/| intro,logic,nlp.people|
+|Schutze, Hinrich|http://www-csli.stanford.edu/~schuetze/csli-homepage.html| nlp.people|
+|Searle, John|http://ist-socrates.berkeley.edu/~jsearle/| phil.people|
+|Sejnowski, Terry|http://www.cnl.salk.edu/CNL/| learning.people|
+|Selker, Ted |http://web.media.mit.edu/~selker/| agents.people Expert in Human-Computer Interaction; inventor of the little red pointing device on your IBM laptop computer.|
+|Selman, Bart|http://www.cs.cornell.edu/home/selman/| intro,logic.people Cornell Prof. working on stochastic algorithms for satisfiability and elated problems.|
+|Shafer, Glenn|http://accounting.rutgers.edu/raw/gsm/glenhome.htm| uncertainty.people Founder of Dempster-Shafer uncertainty theory.|
+|Shanahan, Murray|http://www.dcs.qmw.ac.uk/~mps/| logic.people Author of Solving the Frame Problem.|
+|Shapiro, Stuart|http://www.cs.buffalo.edu/~shapiro/index.html| intro,nlp.people|
+|Shavlik, Jude|http://www.cs.wisc.edu/~shavlik/| learning.people|
+|Shoham, Yoav|http://robotics.stanford.edu/people/shoham/| intro,logic,agents,robotics.people Stanford Prof. working on agents, economic systems.|
+|Signiform|http://www.signiform.com| nlp.com|
+|Simon, Herbert |http://www.psy.cmu.edu/psy/faculty/hsimon/hsimon.html| intro,logic,planning.people|
+|Simplify |http://www.research.digital.com/SRC/esc/Simplify.html| logic.soft|
+|Singh, Munindar |http://www.csc.ncsu.edu/faculty/mpsingh| agents.people|
+|Singh, Satinder|http://www.cs.colorado.edu/~baveja/| learning.people Expert in reinforcement learning.|
+|Singularity Inst.|http://singinst.org/| intro.org Studies Verner Vinge's notion of the singularity: the end of human culture as we know it, due to acceleration of technology.|
+|Siscog|http://www.siscog.pt| planning.com A software company that provides decision-support systems for resource planning and management in transportation companies, especially in the field of railways. |
+|Siskind, Jeffrey|http://dynamo.ecn.purdue.edu/~qobi/| lisp.people|
+|Smolka, Gert|http://ps-www.dfki.uni-sb.de/~smolka/| logic.people|
+|Smyth, Padhraic|http://www-aig.jpl.nasa.gov/home/pjs| learning,uncertainty.people|
+|Soar: Cognitive Architecture|http://kapis.www.wkap.nl/kapis/CGI-BIN/WORLD/book.htm?0-7923-1660-6| agents.ref|
+|Socratic Arts|http://socraticarts.com/| learning.com Company providing online instruction services, based on AI research by Roger Schank and others|
+|Soft Computing|http://link.springer.de/link/service/journals/00500/index.htm| uncertainty.jour|
+|Softbot (Washington) |http://www.cs.washington.edu/research/projects/softbots/www/softbots.html| agents.edu|
+|Software Agents*|http://www.sics.se/isl/abc/survey.html| agents.list|
+|Software for Belief Nets |http://bayes.stat.washington.edu/almond/belief.html| uncertainty.soft|
+|Software list|http://www.emsl.pnl.gov:2080/proj/neuron/ai/systems/| intro.soft|
+|Sowa, John|http://users.bestweb.net/~sowa/direct/| logic.people|
+|Spam Archive*|http://spamarchive.org| nlp.org A collection of spam messages.|
+|Srihari, Sargur|http://www.cedar.buffalo.edu/~srihari/| learning.people|
+|Stabler, Ed|http://www.humnet.ucla.edu/humnet/linguistics/people/stabler/stabler.htm| nlp.people|
+|Stanford Digital Libraries |http://www-diglib.stanford.edu/diglib/| nlp.edu|
+|Stanford Robotics|http://robotics.stanford.edu/| robotics.edu|
+|Stanford Stats|http://playfair.stanford.edu/| uncertainty.edu|
+|Stanford's KSL |http://www-ksl.stanford.edu/| logic.edu The Knowledge System Lab at Stanford; the birthplace of expert systems|
+|Stanford* |http://www.cs.stanford.edu| intro.edu One of the top 4 universities in CS and AI.|
+|Statlib|http://lib.stat.cmu.edu/| learning.soft|
+|Steedman, Mark|http://www.cogsci.ed.ac.uk/~steedman/| nlp.people|
+|Steele, Oliver|http://www.amazon.com/exec/obidos/ASIN/1579122175| nlp,python.people Brandeis Linguistics Prof.; author of PyWordNet.|
+|Stein, Lynn |http://www.ai.mit.edu/people/las/las.html| intro,planning,agents.people|
+|Stickel, Mark |http://www.ai.sri.com/~stickel/| logic.people|
+|Stork, David|http://www.rii.ricoh.com/~stork/| learning.people|
+|Strout, Joe|http://www.strout.net/python/|  python.people|
+|Summer Institute of Linguistics |http://www.sil.org/| nlp.org|
+|Sussman, Jerry|http://www-swiss.ai.mit.edu/~gjs/gjs.html| lisp.people|
+|Sutton, Rich|http://www-anw.cs.umass.edu/~rich/sutton.html| learning.people|
+|Swartout, Bill|http://www.usc.edu/dept/cs/faculty/faculty_interests.html#Swartout| logic.people|
+|SweetRules|http://sweetrules.projects.semwebcentral.org| logic.soft|
+|SyntelSoft|http://www.syntel.com/welcome2.html| uncertainty.com|
+|Szolovits, Peter |http://medg.lcs.mit.edu/people/psz/| intro,uncertainty.people|
+|TARK|http://www.tark.org| logic,agents.org|
+|TIELT|http://nrlsat.ittid.com/| search,learning.edu The Testbed for Integrating and Evaluating Learning Techniques (TIELT) is a free software tool that can be used to integrate AI systems with (e.g., real-time) gaming simulators, and to evaluate how well those systems learn on selected simulation tasks.|
+|TRAINS|http://www.cs.rochester.edu:80/research/trains/| planning,nlp,lisp.soft|
+|Tadepalli, Prasad|http://www.cs.orst.edu:80/~tadepall/| learning.people|
+|Talmy, Len|http://linguistics.buffalo.edu/people/faculty/talmy/talmy.html| nlp.people|
+|Tambe, Milind|http://www.isi.edu/soar/tambe| agents.people|
+|Tanimoto, Steve|http://www.cs.washington.edu/research/metip/tanimoto.html| robotics.people|
+|Tate, Austin |http://www.aiai.ed.ac.uk/~bat/| intro,planning.people|
+|Teknowledge |http://www.teknowledge.com/| intro,logic.com|
+|Tetris|http://cslibrary.stanford.edu/112/| search.soft Java implementation of the Tetris game with an AI player that does quite well.|
+|Texas |http://www.cs.utexas.edu/users/ai-lab/| intro.edu|
+|Texas Research Software|http://www.cs.utexas.edu/users/ml/ml-progs.html| learning.soft|
+|Texas|http://www.cs.utexas.edu/users/ml/| learning.edu|
+|The Data Mine* |http://www.cs.bham.ac.uk/~anp/TheDataMine.html| learning.list|
+|The Future Doesn't Need Us (B. Joy)|http://www.wired.com/wired/archive/8.04/joy.html| phil.ref|
+|The Future Needs Us (F. Dyson)|http://www.nybooks.com/articles/16053| phil.ref|
+|Theorem Provers |http://www-ksl.stanford.edu/people/neller/theorem-provers.html| logic.edu|
+|Theorems Proved|http://www.mcs.anl.gov/home/mccune/ar/new_results/index.html| logic.ref|
+|Thinking Machines|http://www.think.com/| learning,intro.com|
+|ThoughtTreasure|http://www.signiform.com/tt/htm/tt.htm| nlp,lisp.soft|
+|Thrun, Sebastian|http://www.cs.cmu.edu/People/thrun/| robotics.people|
+|Thunderstone |http://www.thunderstone.com/| nlp.com|
+|Tracy, Kim mailto:kimtracy@bell-labs.com java.people Co-author of Object Oriented AI in C+|||
+|Trajecta|http://www.trajecta.com| learning.com|
+|Tuppas|http://tuppas.com/Artificial-Intelligence/Artificial-Intelligence.htm| intro.com AI in Manufacturing|
+|Turing, Alan* |http://www.turing.org.uk/turing/| intro,agents,logic,phil.people One of the founders of computing and AI.|
+|U. Maryland |http://www.cs.umd.edu/projects/tnpfps/index.html| planning.edu|
+|U. Washington |http://www.cs.washington.edu/research/projects/ai/www/ai.html| planning.edu|
+|U. of Washington Statistics |http://www.stat.washington.edu| uncertainty.edu|
+|UAI list* |http://www.auai.org/auai-people.html| uncertainty.people|
+|UCLA Datasets|http://www.stat.ucla.edu/data/| learning.soft|
+|UCLA stats|http://www.stat.ucla.edu| uncertainty.edu|
+|UCPOP |http://www.cs.washington.edu/research/projects/ai/www/ucpop.html| planning.soft A popular paritial-order planner, with free source code.|
+|UMCP Planner|http://www.cs.umd.edu/projects/plus/umcp/manual/| planning,java.soft|
+|UMass |http://www.cs.umass.edu/csinfo/groups.html| intro.edu|
+|UMass Adaptive Networks|http://envy.cs.umass.edu| learning.edu|
+|UMass Anytime Reasoning|http://anytime.cs.umass.edu/| uncertainty,agents.edu|
+|UMass Computer Vision|http://vis-www.cs.umass.edu/| robotics.edu|
+|UMass Machine Learning|http://www.cs.umass.edu/~lrn/| learning.edu|
+|UMass Perceptual Robotics|http://www-robotics.cs.umass.edu/lpr.html| robotics.edu|
+|UPenn |http://www.cis.upenn.edu/cishome.html| intro.edu|
+|US Go Org.|http://www.usgo.org/resources/computer.asp| search.org Computer Go page; lists many Go-playing programs.|
+|USC Modular Robotics|http://www.usc.edu/users/goldberg/mrl.html| robotics.edu|
+|USC Robotics|http://www-robotics.usc.edu| robotics.edu|
+|USC Robotics|http://www-robotics.usc.edu/| robotics.edu|
+|USC/ISI* |http://www.isi.edu/AI/isd.htm| intro.edu Information Sciences Institute of the University of Southern California has a large AI lab focusing in web and natural language processing.|
+|Ultragem |http://www.ultragem.com/| intro,learning.com|
+|Umass Multi-Agent Systems|http://dis.cs.umass.edu/| agents.edu|
+|Uszkoreit, Hans|http://www.dfki.de/~hansu/| nlp.people|
+|Utgoff, Paul|http://www.cs.umass.edu/~utgoff/| learning.people|
+|Valiant, Leslie|http://people.deas.harvard.edu/~valiant/| intro,learning.people|
+|VanLehn, Kurt|http://www.cs.pitt.edu:80/~vanlehn/| learning.people|
+|Veloso, Manuela|http://www.cs.cmu.edu/afs/cs/user/mmv/www/home.html| learning,robotics.people|
+|Verity|http://www.verity.com| agents,nlp.com|
+|Videre (Vision)|http://mitpress.mit.edu/journal-home.tcl?issn=10892788| robotics.jour|
+|Vienna Bibliography |http://www.ai.univie.ac.at/biblio.html| intro.ref|
+|Virtual Library: AI|http://archive.comlab.ox.ac.uk/comp/ai.html| intro.list|
+|Vision and Apps.|http://link.springer.de/link/service/journals/00138/index.htm| robotics.jour|
+|W3C Semantic Web|http://www.w3.org/2001/sw| logic.org|
+|WEKA ML toolkit|http://www.cs.waikato.ac.nz/~ml/| learning.soft A popular toolkit for machine learning.|
+|WPI: MAS list|http://www.cs.wpi.edu/Research/airg/Agents-hotlist.html| agents.list|
+|Waldinger, Richard |http://www.ai.sri.com/~waldinge/| logic,planning.people|
+|WalkSAT for Java|http://sdg.lcs.mit.edu/~dnj/walksat/| logic,java.soft|
+|Waltz, David |http://www.neci.nec.com/homepages/waltz/| intro,robotics,learning.people|
+|Warmuth, Manfred|http://users.soe.ucsc.edu/~manfred/| learning.people|
+|Washington |http://www.cs.washington.edu/research/projects/ai/www/| intro.edu|
+|Watson, Mark|http://www.markwatson.com| lisp,java.people|
+|Web Robots|http://info.webcrawler.com/mak/projects/robots/robots.html| agents.list|
+|Webber, Bonnie |http://www.cis.upenn.edu/~bonnie/home.html| intro,nlp.people|
+|Weld, Dan|http://www.cs.washington.edu/people/faculty/weld.html| learning,planning.people|
+|Wellman, Michael|http://ai.eecs.umich.edu/people/wellman/| agents,intro,uncertainty.people|
+|What is AI*|http://www-formal.stanford.edu/jmc/whatisai/whatisai.html| intro.ref John McCarthy's introduction to AI|
+|Wilensky, Robert |http://www.cs.berkeley.edu/~wilensky/| intro,nlp,planning,lisp.people|
+|Winograd, Terry |http://www-pcd.stanford.edu/hci/people/winograd.html| intro,nlp,agents.people Author of Shrudlu, one of the first NLP programs, which operated in the blocks word.  Now Stanford Prof. working in Human-Computer Interaction.|
+|Winston, Pat|http://www.ai.mit.edu/people/phw/phw.html| intro,logic,lisp.people|
+|Wisconsin ML|http://www.cs.wisc.edu/~shavlik/uwml.html| learning.edu|
+|Witten, Ian|http://www.cs.waikato.ac.nz/~ihw/| learning,nlp.people Waikato Prof., author of Managing Gigabytes, digital libraries, data mining work.|
+|Wooldridge, Michael|http://www.csc.liv.ac.uk/~mjw| agents.people|
+|WordNet in Python|http://pywordnet.sourceforge.net/| python,nlp.soft|
+|WordNet* |http://www.cogsci.princeton.edu/~wn/| nlp.soft The best freeware computer-readable dictionary and ontology|
+|Wos, Larry |http://www-unix.mcs.anl.gov/~wos/| logic.people|
+|Wu, Dekai|http://www.cs.ust.hk/faculty/dekai/bio.html| nlp.people|
+|Xerox PARC|http://www.parc.xerox.com/parc-projects.html| intro.edu|
+|Yale |http://www.cs.yale.edu/research/| intro.edu|
+|Yang, Qiang|http://www.cs.sfu.ca/fas-info/cs/people/Faculty/Yang/| planning.people|
+|Yarowsky, David|http://www.cs.jhu.edu/~yarowsky/| nlp.people Leading researcher in statistical NLP.|
+|Zadeh, Lotfi|http://www.cs.berkeley.edu/People/Faculty/Homepages/zadeh.html| intro,uncertainty.people The founder of Fuzzy Logic.  Berkeley Prof.|
+|Zilberstein, Shlomo|http://www.cs.umass.edu/~shlomo| uncertainty,agents,planning.people UMass Prof. working on robotic planning, anytime algorithms.|
+|Zweben, Monte|http://www.bluemartini.com/company/people_list.jsp| agents.people|
+|cardTAP prover|http://www.cs.man.ac.uk/~franconi/scripts/webtap/| logic.soft An online Java applet thatuses tableau methods to prove propositional formulae|
+|comp.ai*|http://groups.google.com/groups?q=comp.ai| intro.news|
+|comp.ai.edu|http://groups.google.com/groups?q=comp.ai.edu| intro.news|
+|comp.ai.fuzzy|http://groups.google.com/groups?q=comp.ai.fuzzy| uncertainty.news|
+|comp.ai.games|http://groups.google.com/groups?q=comp.ai.games| search.news|
+|comp.ai.genetic|http://groups.google.com/groups?q=comp.ai.genetic| learning.news|
+|comp.ai.jair.announce|http://groups.google.com/groups?q=comp.ai.jair.announce| intro.news|
+|comp.ai.nat-lang|http://groups.google.com/groups?q=comp.ai.nat-lang| nlp.news|
+|comp.ai.neural-nets|http://groups.google.com/groups?q=comp.ai.neural-nets| learning.news|
+|comp.ai.nlang-know-rep|http://groups.google.com/groups?q=comp.ai.nlang-know-rep| nlp.news|
+|comp.ai.philosophy|http://groups.google.com/groups?q=comp.ai.philosophy| phil.news|
+|comp.ai.shells|http://groups.google.com/groups?q=comp.ai.shells| lisp,logic.news|
+|comp.ai.vision|http://groups.google.com/groups?q=comp.ai.vision| robotics.news|
+|comp.constraints|http://groups.google.com/groups?q=comp.constraints| logic.news|
+|comp.lang.c++|http://groups.google.com/groups?q=comp.lang.c++| java.news|
+|comp.lang.clos|http://groups.google.com/groups?q=comp.lang.clos| lisp.news|
+|comp.lang.java|http://groups.google.com/groups?q=comp.lang.java| java.news|
+|comp.lang.lisp|http://groups.google.com/groups?q=comp.lang.lisp| lisp.news|
+|comp.lang.prolog|http://groups.google.com/groups?q=comp.lang.prolog| prolog.news|
+|comp.lang.python|http://groups.google.com/groups?q=comp.lang.python| python.news|
+|comp.lang.scheme|http://groups.google.com/groups?q=comp.lang.scheme| lisp.news|
+|comp.lang.smalltalk|http://groups.google.com/groups?q=comp.lang.smalltalk| lisp.news|
+|comp.robotics FAQ|http://www.frc.ri.cmu.edu/~nivek/faq/TOC.html| robotics.ref|
+|comp.robotics|http://groups.google.com/groups?q=comp.robotics| robotics.news|
+|comp.robotics.research |http://groups.google.com/groups?q=comp.robotics.research| robotics.news|


### PR DESCRIPTION
@norvig A little python script did the work to convert [links.txt](https://github.com/aimacode/old-links/blob/master/links.txt) into a well-structured [link.md](https://github.com/ritwik12/old-links/blob/patch-1/links.md) in the form of a table. It can be added to README.md directly too. Based on the way you want it to be used.